### PR TITLE
Add except+ statements to RtMidi methods

### DIFF
--- a/rtmidi2.pyx
+++ b/rtmidi2.pyx
@@ -63,23 +63,23 @@ API_RTMIDI_DUMMY = RTMIDI_DUMMY
 cdef extern from "RtMidi/RtMidi.h":
     ctypedef void (*RtMidiCallback)(double timeStamp, vector[unsigned char]* message, void* userData)
     cdef cppclass RtMidi:
-        void openPort(unsigned int portNumber)
-        void openVirtualPort(string portName)
+        void openPort(unsigned int portNumber) except+
+        void openVirtualPort(string portName) except+
         unsigned int getPortCount()
-        string getPortName(unsigned int portNumber)
-        void closePort()
+        string getPortName(unsigned int portNumber) except+
+        void closePort() except+
 
     cdef cppclass RtMidiIn(RtMidi):
-        RtMidiIn(RtMidi.Api api, string clientName, unsigned int queueSizeLimit)
-        void setCallback(RtMidiCallback callback, void* userData)
-        void cancelCallback()
+        RtMidiIn(RtMidi.Api api, string clientName, unsigned int queueSizeLimit) except+
+        void setCallback(RtMidiCallback callback, void* userData) except+
+        void cancelCallback() except+
         void ignoreTypes(bint midiSysex, bint midiTime, bint midiSense)
-        double getMessage(vector[unsigned char]* message)
+        double getMessage(vector[unsigned char]* message) except+
 
     cdef cppclass RtMidiOut(RtMidi):
-        RtMidiOut(RtMidi.Api api, string clientName)
+        RtMidiOut(RtMidi.Api api, string clientName) except+
         # RtMidiOut()
-        void sendMessage(vector[unsigned char]* message)
+        void sendMessage(vector[unsigned char]* message) except+
         Api getCurrentApi()
 
 cdef class MidiBase:


### PR DESCRIPTION
On Windows, opening a port twice caused the program to exit without an exception:

```python
>>> import rtmidi2
>>> rtmidi2.MidiIn().open_port()
<rtmidi2.MidiIn object at 0x04A38ED0>
>>> rtmidi2.MidiIn().open_port()
MidiInWinMM::openPort: error creating Windows MM MIDI input port.
Process finished with exit code -1073740791 (0xC0000409)
```

Adding `except +` now raises a `RuntimeError`, but does not exit instantly:

```python
>>> import rtmidi2
>>> rtmidi2.MidiIn().open_port()
<rtmidi2.MidiIn object at 0x04838ED0>
>>> rtmidi2.MidiIn().open_port()
MidiInWinMM::openPort: error creating Windows MM MIDI input port.
Traceback (most recent call last):
  File "<input>", line 1, in <module>
  File "rtmidi2.pyx", line 123, in rtmidi2.MidiBase.open_port
    self.baseptr().openPort(port_number)
RuntimeError: MidiInWinMM::openPort: error creating Windows MM MIDI input port.
>>>
```

I added  `except +` to every method that could possibly throw a C++ exception.