### PR TITLE
Update project metadata (new structure)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,11 +3,9 @@ name = "rtmidi2"
 authors = [
     { name = "Eduardo Moguillansky", email = "eduardo.moguillansky@gmail.com" }
 ]
-license = "MIT"
 readme = "README.rst"
-requires_python = "^3.8"
-homepage = "https://github.com/gesellkammer/rtmidi2"
-repository = "https://github.com/gesellkammer/rtmidi2"
+license = {file = "LICENSE"}
+requires-python = ">=3.8"
 
 classifiers = [
     "Topic :: Software Development"
@@ -16,10 +14,13 @@ classifiers = [
 [build-system]
 
 requires = [
-    "setuptools>=42",
+    "setuptools>=61",
     "wheel",
     "cython"
 ]
 
 build-backend = "setuptools.build_meta"
 
+[project.urls]
+homepage = "https://github.com/gesellkammer/rtmidi2"
+repository = "https://github.com/gesellkammer/rtmidi2"

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import sys
 from setuptools import setup, Extension
 
-version = "1.1.0" 
+version = "1.1.1"
 
 module_source = 'rtmidi2.pyx'
 


### PR DESCRIPTION
## Update project metadata with new structure

* Update pyproject.toml file with new file structure.
  * The reference used to fix this file: https://peps.python.org/pep-0621/#license
  * This change is expected to work fine with `setuptools >=61`
* Update setup.py with a new library version.
  * Suggesting new version for the library (1.1.1) .
 