### PR TITLE
Make pyproject.toml PEP 621/508 compliant

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,17 +1,20 @@
 [project]
 name = "rtmidi2"
+description = "Python wrapper for RtMidi written in Cython. Allows sending raw messages, multi-port input and sending multiple messages in one call."
 authors = [
     { name = "Eduardo Moguillansky", email = "eduardo.moguillansky@gmail.com" }
 ]
-license = "MIT"
+license = { text = "MIT" }
 readme = "README.rst"
-requires_python = "^3.8"
-homepage = "https://github.com/gesellkammer/rtmidi2"
-repository = "https://github.com/gesellkammer/rtmidi2"
-
+requires-python = ">=3.8"
+version = "1.1.0"
 classifiers = [
     "Topic :: Software Development"
 ]
+
+[project.urls]
+homepage = "https://github.com/gesellkammer/rtmidi2"
+repository = "https://github.com/gesellkammer/rtmidi2"
 
 [build-system]
 

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Topic :: Software Development :: Libraries :: Python Modules'
     ],
-    description='Python wrapper for RtMidi written in Cython. Allows sending raw messages, multi-port input and sending multiple messages in one call.',
+    dynamic=['description'],
     long_description=long_description,
     author='originally by Guido Lorenz, modified by Eduardo Moguillansky',
     author_email='eduardo.moguillansky@gmail.com',


### PR DESCRIPTION
This patch allows rtmidi2 to be installed with tools that follow PEP 621, such as pdm.
It also fixes a `setuptools` deprecation warning, regarding the `description` field, that is now read from `pyproject.toml`.

- https://peps.python.org/pep-0621/